### PR TITLE
feat: remove kawa cask in homebrew

### DIFF
--- a/modules/darwin/homebrew/casks.nix
+++ b/modules/darwin/homebrew/casks.nix
@@ -1,4 +1,5 @@
-{ ... }: {
+{ ... }:
+{
   homebrew = {
     casks = [
       "raycast"
@@ -13,7 +14,7 @@
       "whatsapp"
       "lulu"
       # "obsidian"
-      "kawa"
+      # "kawa"
       # "meetingbar"
       # "hiddenbar"
 


### PR DESCRIPTION
Removed the kawa cask from the homebrew casks list for better organization.