### PR TITLE
refactor: Comment out unused dependencies in wilder plugin configuration

### DIFF
--- a/modules/config/nvim/lua/k92/plugins/wilder.lua
+++ b/modules/config/nvim/lua/k92/plugins/wilder.lua
@@ -6,9 +6,9 @@ return {
 			"/",
 			"?",
 		},
-		dependencies = {
-			"catppuccin/nvim",
-		},
+		-- dependencies = {
+		-- 	"catppuccin/nvim",
+		-- },
 		config = function()
 			local wilder = require("wilder")
 			local macchiato =


### PR DESCRIPTION
Commented out the dependencies declaration in the wilder plugin configuration
to improve code readability and reduce clutter. This declaration is currently
unused and can be safely removed.