### PR TITLE
feat: Add new Safari extensions to mas-apps.nix

### DIFF
--- a/modules/darwin/homebrew/mas-apps.nix
+++ b/modules/darwin/homebrew/mas-apps.nix
@@ -2,11 +2,11 @@
 {
   homebrew = {
     masApps = {
-      "prettyJSON for Safari" = 1445328303;
       "Wappalyzer" = 1520333300;
       "Vimari" = 1480933944;
-      "Super Agent for Safari" = 1568262835;
       "AdGuard for Safari" = 1440147259;
+      "Consent-O-Matic" = 1606897889;
+      "JSON Peep for Safari" = 1458969831;
     };
   };
 }


### PR DESCRIPTION
Added "Consent-O-Matic" and "JSON Peep for Safari" to the list of Safari extensions in mas-apps.nix file. Removed "Super Agent for Safari" and "prettyJSON for Safari".