### PR TITLE
feat: Add Spotlight to blacklist in SVIM config

### DIFF
--- a/modules/config/svim/blacklist
+++ b/modules/config/svim/blacklist
@@ -5,3 +5,4 @@ MacVim
 Neovide
 Terminal
 Xcode
+Spotlight


### PR DESCRIPTION
Add Spotlight to the SVIM blacklist in order to prevent it from being launched
accidentally during development.