### PR TITLE
feat: Update link hint characters

### DIFF
--- a/modules/config/vimari/vimari.json
+++ b/modules/config/vimari/vimari.json
@@ -1,6 +1,6 @@
 {
   "excludedUrls": "",
-  "linkHintCharacters": "aoeusnthid",
+  "linkHintCharacters": "htnsgcrl",
   "detectByCursorStyle": true,
   "scrollSize": 150,
   "openTabUrl": "https://duckduckgo.com/",


### PR DESCRIPTION
Changed link hint characters to "htnsgcrl" to improve usability and efficiency in
Vimari.