### PR TITLE
feat: Add Vimlike extension and update mappings

### DIFF
--- a/modules/config/vimlike/settings.txt
+++ b/modules/config/vimlike/settings.txt
@@ -1,0 +1,46 @@
+// Scroll
+settings.map('j', VLCommand.SCROLL_DOWN);
+settings.map('k', VLCommand.SCROLL_UP);
+settings.map('h', VLCommand.SCROLL_LEFT);
+settings.map('l', VLCommand.SCROLL_RIGHT);
+settings.map('ctrl+d', VLCommand.HALF_PAGE_DOWN);
+settings.map('ctrl+u', VLCommand.HALF_PAGE_UP);
+settings.map('g g', VLCommand.SCROLL_TO_TOP);
+settings.map('shift+g', VLCommand.SCROLL_TO_BOTTOM);
+
+// Normal mode
+settings.map('f', VLCommand.ACTIVATE_LINK);
+settings.map('shift+f', VLCommand.ACTIVATE_LINK_WITH_NEW_TAB);
+settings.map('shift+h', VLCommand.GO_BACK);
+settings.map('shift+l', VLCommand.GO_FORWARD);
+settings.map('shift+k', VLCommand.PREV_TAB);
+settings.map('shift+j', VLCommand.NEXT_TAB);
+settings.map('t', VLCommand.NEW_TAB);
+settings.map('g i', VLCommand.FOCUS_INPUT);
+settings.map('slash', VLCommand.SHOW_CONSOLE);
+settings.map('ctrl+i', VLCommand.INSERT_MODE);
+settings.map('g 1', VLCommand.OPEN_TAB1);
+settings.map('g 2', VLCommand.OPEN_TAB2);
+settings.map('g 3', VLCommand.OPEN_TAB3);
+settings.map('g 4', VLCommand.OPEN_TAB4);
+settings.map('g 5', VLCommand.OPEN_TAB5);
+settings.map('g 6', VLCommand.OPEN_TAB6);
+settings.map('g 7', VLCommand.OPEN_TAB7);
+settings.map('g 8', VLCommand.OPEN_TAB8);
+settings.map('g 9', VLCommand.OPEN_TAB9);
+settings.map('g shift+4', VLCommand.OPEN_LAST_TAB);
+settings.map('g 0', VLCommand.OPEN_TAB1);
+settings.map('d', VLCommand.CLOSE_TAB);
+settings.map('shift+1', VLCommand.VIDEO_FULLSCREEN);
+settings.map('shift+2', VLCommand.VIDEO_PIP);
+settings.map('shift+3', VLCommand.DARK_MODE);
+settings.map('r', VLCommand.RELOAD);
+settings.map('?', VLCommand.TOGGLE_HELP);
+settings.map('shift+slash', VLCommand.TOGGLE_HELP);
+settings.map('/', VLCommand.SHOW_CONSOLE);
+settings.map('y y', VLCommand.COPY_CURRENT_URL);
+settings.map('y t', VLCommand.DUPLICATE_TAB);
+settings.map('g shift+u', VLCommand.GO_TO_URL_ROOT);
+settings.map('g u', VLCommand.GO_TO_URL_UP);
+settings.map('m', VLCommand.ZOOM_IN);
+settings.map('shift+r', VLCommand.TOGGLE_READER_MODE);

--- a/modules/darwin/homebrew/mas-apps.nix
+++ b/modules/darwin/homebrew/mas-apps.nix
@@ -3,10 +3,11 @@
   homebrew = {
     masApps = {
       "Wappalyzer" = 1520333300;
-      "Vimari" = 1480933944;
+      # "Vimari" = 1480933944;
       "AdGuard for Safari" = 1440147259;
       "Consent-O-Matic" = 1606897889;
       "JSON Peep for Safari" = 1458969831;
+      "Vimlike" = 1584519802;
     };
   };
 }


### PR DESCRIPTION
Add the "Vimlike" extension to the list of MAS apps in the Nix configuration file.
Update the settings.txt file for the Vimlike extension with new key mappings for scrolling, navigation, tab management, video control, dark mode, reload, help, and URL actions.