### PR TITLE
feat(nvim): Add logic to reveal correct file/folder in NeoTree

### DIFF
--- a/modules/config/nvim/lua/k92/plugins/neo-tree.lua
+++ b/modules/config/nvim/lua/k92/plugins/neo-tree.lua
@@ -14,22 +14,24 @@ return {
 		{
 			"<leader>e",
 			function()
+				local reveal_file = vim.fn.expand("%:p")
+				if reveal_file == "" then
+					reveal_file = vim.fn.getcwd()
+				else
+					local f = io.open(reveal_file, "r")
+					if f then
+						f.close(f)
+					else
+						reveal_file = vim.fn.getcwd()
+					end
+				end
 				require("neo-tree.command").execute({
 					toggle = true,
-					dir = vim.fn.getcwd(),
+					reveal_file = reveal_file, -- path to file or folder to reveal
+					reveal_force_cwd = true, -- change cwd without asking if needed
 				})
 			end,
 			desc = "Explorer NeoTree (Root Dir)",
-		},
-		{
-			"<leader>E",
-			function()
-				require("neo-tree.command").execute({
-					toggle = true,
-					dir = vim.uv.cwd(),
-				})
-			end,
-			desc = "Explorer NeoTree (cwd)",
 		},
 	},
 	deactivate = function()


### PR DESCRIPTION
Add logic to retrieve the correct path to a file or folder in NeoTree based
on the current buffer or current working directory. This ensures that the
NeoTree is always opened at the right location.