### PR TITLE
refactor: Remove unnecessary demo Virtual Machine configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,24 +51,6 @@
     in
     {
       darwinConfigurations = {
-        demos-Virtual-Machine = darwinSystem {
-          system = "aarch64-darwin";
-          pkgs = import nixpkgs-unstable { system = "aarch64-darwin"; };
-          specialArgs = {
-            inherit inputs;
-          };
-          modules = [
-            {
-              home-manager = {
-                useGlobalPkgs = true;
-                useUserPackages = true;
-                users.demo.imports = [ ./modules/home-manager/default-personal.nix ];
-              };
-            }
-          ];
-          username = "demo";
-        };
-
         Kyles-MacBook-Air = darwinSystem {
           system = "aarch64-darwin";
           pkgs = import nixpkgs-unstable { system = "aarch64-darwin"; };


### PR DESCRIPTION
Removed the demo Virtual Machine configuration from flake.nix as it is no longer needed.