### PR TITLE
fix: Enable luajitPackages.luarocks for neovim functionality

### DIFF
--- a/modules/home-manager/home/packages/default.nix
+++ b/modules/home-manager/home/packages/default.nix
@@ -23,7 +23,7 @@ in
       agkozak-zsh-prompt
       # --- neovim ---
       # luajit
-      # luajitPackages.luarocks # for nvim
+      luajitPackages.luarocks # for nvim
       nixfmt-rfc-style # for nvim
       codespell # for nvim
       beautysh # for nvim


### PR DESCRIPTION
Enable the luajitPackages.luarocks package for neovim to ensure proper
functionality. Remove commented out line for clarity.