### PR TITLE
fix: enable luajit in neovim

### DIFF
--- a/modules/home-manager/home/packages/default.nix
+++ b/modules/home-manager/home/packages/default.nix
@@ -22,7 +22,7 @@ in
       jq
       agkozak-zsh-prompt
       # --- neovim ---
-      # luajit
+      luajit
       luajitPackages.luarocks # for nvim
       nixfmt-rfc-style # for nvim
       codespell # for nvim


### PR DESCRIPTION
Remove comment disabling luajit in neovim to enable its usage.