### PR TITLE
feat: Add zerotier-one to Homebrew casks

### DIFF
--- a/modules/darwin/homebrew/casks.nix
+++ b/modules/darwin/homebrew/casks.nix
@@ -13,6 +13,7 @@
       "imageoptim"
       "whatsapp"
       "lulu"
+      "zerotier-one"
       # "obsidian"
       # "kawa"
       # "meetingbar"


### PR DESCRIPTION
Add zerotier-one to the list of applications in the Homebrew casks file to make
it easier for users to install. This software is commonly used and requested by
users.