### PR TITLE
fix(core): fix typo in isfname option

### DIFF
--- a/modules/config/nvim/lua/k92/core/options.lua
+++ b/modules/config/nvim/lua/k92/core/options.lua
@@ -75,7 +75,7 @@ opt.updatetime = 50 -- Save swap file and trigger CursorHold
 
 -- words
 opt.iskeyword:append("-") -- consider string-string as whole words
-opt.isfnname:append("@-@")
+opt.isfname:append("@-@")
 opt.fillchars = {
 	foldopen = "",
 	foldclose = "",


### PR DESCRIPTION
Changed isfnname to isfname in order to correctly set option for considering
string-string as whole words. This fixes an issue where incorrect option
was being used.