### PR TITLE
feat: Add custom handler for textDocument/hover in LSP config

### DIFF
--- a/modules/config/nvim/lua/k92/plugins/lspconfig.lua
+++ b/modules/config/nvim/lua/k92/plugins/lspconfig.lua
@@ -292,5 +292,29 @@ return {
 				end,
 			},
 		})
+
+		vim.lsp.handlers["textDocument/hover"] = function(
+			_,
+			result,
+			ctx,
+			config
+		)
+			config = config or {}
+			config.focus_id = ctx.method
+			if not (result and result.contents) then
+				return
+			end
+			local markdown_lines =
+				vim.lsp.util.convert_input_to_markdown_lines(result.contents)
+			markdown_lines = vim.lsp.util.trim_empty_lines(markdown_lines)
+			if vim.tbl_isempty(markdown_lines) then
+				return
+			end
+			return vim.lsp.util.open_floating_preview(
+				markdown_lines,
+				"markdown",
+				config
+			)
+		end
 	end,
 }


### PR DESCRIPTION
Customized the handling of hover requests in the LSP configuration to display
markdown content in a floating preview window. This improves the user
experience by providing a more readable and focused display of hover
information.