### PR TITLE
feat: Add neovim alias for 'n' command and 'nivm'

### DIFF
--- a/modules/home-manager/programs/fish/default.nix
+++ b/modules/home-manager/programs/fish/default.nix
@@ -30,11 +30,13 @@
         nixup = "pushd ~/nix-system-config; nix flake update; nixswitch; popd";
         nixcleanup = "bash ~/nix-system-config/cleanup.sh";
         cat = "bat";
+        n = "nvim";
         nim = "nvim";
         vim = "nvim";
         nvm = "nvim";
         vi = "nvim";
         nvi = "nvim";
+        nivm = "nvim";
       };
       plugins = [
         {


### PR DESCRIPTION
Added neovim as an alias for 'n' command and 'nivm' in the fish shell configuration file.