### PR TITLE
feat: Enable query linter in nvim-treesitter

### DIFF
--- a/modules/config/nvim/lua/k92/plugins/nvim-treesitter.lua
+++ b/modules/config/nvim/lua/k92/plugins/nvim-treesitter.lua
@@ -68,6 +68,11 @@ return {
 					"vimdoc",
 					"yaml",
 				},
+				query_linter = {
+					enable = true,
+					use_virtual_text = true,
+					lint_events = { "BufWrite", "CursorHold" },
+				},
 				incremental_selection = {
 					enable = true,
 					keymaps = {


### PR DESCRIPTION
Enabled query linter in nvim-treesitter for better code linting. Uses virtual
text and triggers linting on BufWrite and CursorHold events.