### PR TITLE
refactor: Remove unnecessary autocmds for macro recording

### DIFF
--- a/modules/config/nvim/lua/k92/core/autocmds.lua
+++ b/modules/config/nvim/lua/k92/core/autocmds.lua
@@ -106,17 +106,17 @@ autocmd({ "BufWritePre" }, {
 	end,
 })
 
--- Make cmdheight 1 if entering macro
-autocmd("RecordingEnter", {
-	pattern = "*",
-	command = "set cmdheight=2",
-})
-
--- Make cmdheight 0 if leaving macro
-autocmd("RecordingLeave", {
-	pattern = "*",
-	command = "set cmdheight=0",
-})
+-- -- Make cmdheight 1 if entering macro
+-- autocmd("RecordingEnter", {
+-- 	pattern = "*",
+-- 	command = "set cmdheight=2",
+-- })
+--
+-- -- Make cmdheight 0 if leaving macro
+-- autocmd("RecordingLeave", {
+-- 	pattern = "*",
+-- 	command = "set cmdheight=0",
+-- })
 
 -- Turn off paste mode when leaving insert
 autocmd("InsertLeave", {


### PR DESCRIPTION
Removed autocmds for setting cmdheight to 2 when entering a macro and 0 when leaving,
which are no longer needed as they were causing conflicts with other configurations.