### PR TITLE
refactor: Remove unused key bindings for file searching

### DIFF
--- a/modules/config/nvim/lua/k92/plugins/telescope.lua
+++ b/modules/config/nvim/lua/k92/plugins/telescope.lua
@@ -98,24 +98,6 @@ return {
 		local extensions = require("telescope").extensions
 		local keymap = vim.keymap -- for conciseness
 
-		-- keymap.set(
-		-- 	"n",
-		-- 	"<leader><space>",
-		-- 	builtin.find_files,
-		-- 	{ desc = "[S]earch [F]iles" }
-		-- )
-		keymap.set(
-			"n",
-			"<leader>sf",
-			builtin.find_files,
-			{ desc = "[S]earch [F]iles" }
-		)
-		keymap.set(
-			"n",
-			"<leader>s.",
-			builtin.oldfiles,
-			{ desc = "[S]earch Recent Files" }
-		)
 		keymap.set(
 			"n",
 			"<leader>sd",
@@ -133,12 +115,6 @@ return {
 			"<leader>sw",
 			builtin.grep_string,
 			{ desc = "[S]earch current [W]ord" }
-		)
-		keymap.set(
-			"n",
-			"<leader>sb",
-			"<cmd>Telescope current_buffer_fuzzy_find<cr>",
-			{ desc = "[S]earch current [B]buffer Fuzzy" }
 		)
 		keymap.set(
 			"n",


### PR DESCRIPTION
Removed unused key bindings for searching files and current buffer fuzzy search in the Telescope plugin configuration file to declutter the keymap setup.