### PR TITLE
feat: Update key mappings for diagnostic messages

### DIFF
--- a/modules/config/nvim/lua/k92/plugins/lspconfig.lua
+++ b/modules/config/nvim/lua/k92/plugins/lspconfig.lua
@@ -112,12 +112,12 @@ return {
 				map("gD", vim.lsp.buf.declaration, "[G]oto [D]eclaration")
 
 				map(
-					"<C-j>",
+					"[d",
 					vim.diagnostic.goto_prev,
 					"Go to previous Diagnostic message"
 				)
 				map(
-					"<C-k>",
+					"]d",
 					vim.diagnostic.goto_next,
 					"Go to next Diagnostic message"
 				)


### PR DESCRIPTION
Changed key mappings for navigating between previous and next diagnostic
messages to use more intuitive key bindings: [d for previous diagnostic and
]d for next diagnostic. This improves user experience and efficiency.