### PR TITLE
feat: use ',' as localleader

### DIFF
--- a/modules/config/nvim/lua/config/options.lua
+++ b/modules/config/nvim/lua/config/options.lua
@@ -3,6 +3,7 @@
 -- Add any additional options here
 
 local opt = vim.opt
+vim.g.maplocalleader = ","
 
 -- Lazygit
 vim.g.lazygit_config = false


### PR DESCRIPTION
Lazyvim default localleader is '/', switch to ',' as '/' is interfering with `searches`
